### PR TITLE
Feat/tracing xetrack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,9 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Development files
+.cursor/
+logs/
+tmp/
+tracing.db

--- a/README.md
+++ b/README.md
@@ -250,13 +250,13 @@ mcp-gateway --enable-tracing xetrack
             "command": "mcp-gateway",
             "args": [
                 "--mcp-json-path",
-                "~/development/xdss/mcp-gateway/.cursor/mcp.json",
+                "~/.cursor/mcp.json",
                 "--enable-tracing",
                 "xetrack"
             ],
             "env": {
                 "XETRACK_DB_PATH": "tracing.db",
-                "XETRACK_LOGS_PATH": "logs/",                
+                "XETRACK_LOGS_PATH": "logs/"                
             },
             "servers": {
                 "filesystem": {

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ mcp-gateway --enable-tracing xetrack
 }
 ```
 
-Let's say you use the  filesystem *list_directory* tool on path *"."*, you can find the call parameters under `/logs/<date>.log`.
+Let's say you use the  filesystem *list_directory* tool on path *"."*, you can find the call parameters under `logs/<date>.log`.
 
 You can expolre using [xetrack cli](https://github.com/xdssio/xetrack?tab=readme-ov-file#cli) to query the db:
 

--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ Key Features
 ## Tracing
 
 ### Xetrack
-[xetrack](https://github.com/xdssio/xetrack) is a lightweight package to track experiments benchmarks, and monitor stractured data using duckdb and sqlite.
-It will create and maintian a database with each tool_call for you to explore with duckdb, sqlite or pandas using xetrack.
-It can also log to logs folder.
+[xetrack](https://github.com/xdssio/xetrack) is a lightweight package to track ml experiments, benchmarks, and monitor stractured data.
+
+We can use it to debug and monitor **tool calls** with logs ([loguru](https://github.com/Delgan/loguru)) or [duckdb](https://duckdb.org) and [sqlite](https://sqlite.org).   .
 
 ```bash
 mcp-gateway --enable-tracing xetrack
@@ -232,8 +232,18 @@ mcp-gateway --enable-tracing xetrack
 #### Prerequisites
 `pip install xetrack`
 
-Example 
-```
+#### Params
+* `XETRACK_DB_PATH` - The sqlite db location. 
+    * All logs register in the *events* table.
+    * If fancy objects return from the MCPs response, read about xetrack [assets](https://github.com/xdssio/xetrack?tab=readme-ov-file#track-assets-oriented-for-ml-models) to retrive it. 
+* `XETRACK_LOGS_PATH` - The logs location
+* `FLATTEN_ARGUMENTS` - Flatten the arguments, default `true`
+* `FLATTEN_RESPONSE` - Flatten the response, default `true`
+* It is recommend to to gitignore the logs location
+* It is recommended to use [DVC](http://dvc.org) to manage the db file
+
+#### Quickstart 
+```json
 {
     "mcpServers": {
         "mcp-gateway": {
@@ -254,7 +264,7 @@ Example
                     "args": [
                         "-y",
                         "@modelcontextprotocol/server-filesystem",
-                        "./tests"
+                        "."
                     ]
                 }
             }
@@ -262,6 +272,58 @@ Example
     }
 }
 ```
+
+Let's say you use the  filesystem *list_directory* tool on path *"."*, you can find the call parameters under `/logs/<date>.log`.
+
+You can expolre using [xetrack cli](https://github.com/xdssio/xetrack?tab=readme-ov-file#cli) to query the db:
+
+```bash
+$ xt tail tracing.db --json --n=1
+[
+    {
+        "timestamp": "2025-04-17 17:12:48.233126",
+        "track_id": "mottled-stingray-0411",
+        "meta": "f3be31e09667745f",
+        "paths": null,
+        "call_id": "deab617e-0a45-4950-9de9-3fb549810cf2",
+        "capability_name": "list_directory",
+        "content_type": "text",
+        "content_annotations": "f3be31e09667745f",
+        "response_type": "CallToolResult",
+        "server_name": "filesystem",
+        "capability_type": "tool",
+        "isError": 0,
+        "content_text": "[DIR] .cursor\n[DIR] .git\n[FILE] .gitignore\n[DIR] .pytest_cache\n[DIR] .venv\n[FILE] LICENSE\n[FILE] MANIFEST.in\n[FILE] README.md\n[DIR] docs\n[DIR] logs\n[DIR] mcp_gateway\n[FILE] pyproject.toml\n[FILE] requirements.txt\n[DIR] tests\n[DIR] tmp",
+        "path": ".",
+        "prompt": null
+    }
+]
+```
+With python
+```python
+from xetrack import Reader
+
+df = Reader("tracing.db").to_df()
+```
+
+
+With duckdb cli and ui 
+```bash
+$ duckdb --ui
+D INSTALL sqlite; LOAD sqlite; ATTACH 'tracing.db' (TYPE sqlite);
+D SELECT server_name,capability_name,path,content_text FROM db.events LIMIT 1;
+
+┌─────────────┬─────────────────┬─────────┬────────────────────────────────────┐
+│ server_name │ capability_name │  path   │            content_text            │
+│   varchar   │     varchar     │ varchar │              varchar               │
+├─────────────┼─────────────────┼─────────┼────────────────────────────────────┤
+│ filesystem  │ list_directory  │ .       │ [DIR] .cursor\n[DIR] .git\n[FILE…  │
+└─────────────┴─────────────────┴─────────┴────────────────────────────────────┘
+```
+
+Of course you can use another MCP server to query the sqlite database 😊
+
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,51 @@ Key Features
 * Provides usage analytics and pattern identification for optimization.
 * Sanitizes sensitive information before forwarding requests to other MCPs.
 
+## Tracing
+
+### Xetrack
+[xetrack](https://github.com/xdssio/xetrack) is a lightweight package to track experiments benchmarks, and monitor stractured data using duckdb and sqlite.
+It will create and maintian a database with each tool_call for you to explore with duckdb, sqlite or pandas using xetrack.
+It can also log to logs folder.
+
+```bash
+mcp-gateway --enable-tracing xetrack
+
+```
+#### Prerequisites
+`pip install xetrack`
+
+Example 
+```
+{
+    "mcpServers": {
+        "mcp-gateway": {
+            "command": "mcp-gateway",
+            "args": [
+                "--mcp-json-path",
+                "~/development/xdss/mcp-gateway/.cursor/mcp.json",
+                "--enable-tracing",
+                "xetrack"
+            ],
+            "env": {
+                "XETRACK_DB_PATH": "tracing.db",
+                "XETRACK_LOGS_PATH": "logs/",                
+            },
+            "servers": {
+                "filesystem": {
+                    "command": "npx",
+                    "args": [
+                        "-y",
+                        "@modelcontextprotocol/server-filesystem",
+                        "./tests"
+                    ]
+                }
+            }
+        }
+    }
+}
+```
+
 ## License
 
 MIT

--- a/mcp_gateway/plugins/base.py
+++ b/mcp_gateway/plugins/base.py
@@ -39,7 +39,7 @@ class PluginContext:
         }
     
     def _replace(self, arguments: Dict[str,Any]) -> bool:
-        self.arguments =arguments
+        self.arguments = arguments
         return True
 
 # --- Base Plugin Interface ---

--- a/mcp_gateway/plugins/base.py
+++ b/mcp_gateway/plugins/base.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 
-
 class PluginContext:
     """Holds contextual information for plugin execution."""
 
@@ -38,7 +37,10 @@ class PluginContext:
             "response": self.response,
             "mcp_context": self.mcp_context,
         }
-
+    
+    def _replace(self, arguments: Dict[str,Any]) -> bool:
+        self.arguments =arguments
+        return True
 
 # --- Base Plugin Interface ---
 

--- a/mcp_gateway/plugins/base.py
+++ b/mcp_gateway/plugins/base.py
@@ -1,12 +1,9 @@
 import abc
 import logging
-from typing import Any, Dict, Optional, Tuple, List
-
-from mcp import types
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
-# --- Plugin Context ---
 
 
 class PluginContext:
@@ -30,6 +27,17 @@ class PluginContext:
         logger.debug(
             f"PluginContext created for {server_name}/{capability_type}/{capability_name}"
         )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert PluginContext to a dictionary."""
+        return {
+            "server_name": self.server_name,
+            "capability_type": self.capability_type,
+            "capability_name": self.capability_name,
+            "arguments": self.arguments,
+            "response": self.response,
+            "mcp_context": self.mcp_context,
+        }
 
 
 # --- Base Plugin Interface ---
@@ -96,8 +104,6 @@ class GuardrailPlugin(Plugin, abc.ABC):
         """Sanitize or validate response data."""
         pass
 
-
-# --- Tracing Plugin Interface ---
 
 
 class TracingPlugin(Plugin, abc.ABC):

--- a/mcp_gateway/plugins/tracing/xetrack.py
+++ b/mcp_gateway/plugins/tracing/xetrack.py
@@ -1,0 +1,137 @@
+import logging
+import os
+from typing import Any, Dict, List, Optional
+from xetrack import Tracker
+from xetrack.logging import LOGURU_PARAMS
+from mcp_gateway.plugins.base import TracingPlugin, PluginContext
+
+logger = logging.getLogger(__name__)
+
+class XetrackParams:
+    """Parameters for Xetrack tracing."""
+    WARNINGS:bool = os.getenv("XETRACK_WARNINGS", "False").lower() == "true"
+    LOG_SYSTEM_PARAMS:bool = os.getenv("XETRACK_LOG_SYSTEM_PARAMS", "false").lower() == "true"
+    LOG_NETWORK_PARAMS:bool = os.getenv("XETRACK_LOG_NETWORK_PARAMS", "false").lower() == "true"    
+    DB_PATH:str = os.getenv("XETRACK_DB_PATH", Tracker.SKIP_INSERT)
+    LOGS_PATH:str|None = os.getenv("XETRACK_LOGS_PATH", None)
+    LOGS_STDOUT:bool = os.getenv("XETRACK_LOGS_STDOUT", "false").lower() == "true"
+    FLATTEN_RESPONSE:bool = os.getenv("XETRACK_FLATTEN_RESPONSE", "true").lower() == "true"
+    FLATTEN_ARGUMENTS:bool = os.getenv("XETRACK_FLATTEN_ARGUMENTS", "true").lower() == "true"    
+    LOG_FORMAT:str = os.getenv("XETRACK_LOG_FORMAT", LOGURU_PARAMS.LOG_FILE_FORMAT)
+
+def to_events(context: PluginContext, event: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Format the response data for logging.
+    
+    Args:
+        context: The plugin context containing the response
+        event: The event dictionary to update with response data
+        
+    Returns:
+        The updated event dictionary
+    """
+
+    if XetrackParams.FLATTEN_ARGUMENTS:
+        arguments = context.arguments or {}
+        for key, value in arguments.items():
+            event[key] = value
+        event.pop("arguments", None)
+
+    response = context.response or {}
+    event["response_type"] = 'unknown' if response is None else type(response).__name__ # type: ignore
+    for key, value in response.items():
+        event[key] = value        
+    event.pop("response", None)
+
+    
+    try:
+        if hasattr(context.response, "model_dump"):
+            response = context.response.model_dump()
+        elif (
+            isinstance(response, tuple)
+            and len(response) == 2 # type: ignore
+        ):
+            # For resource responses (content, mime_type)
+            content, mime_type = context.response
+            if mime_type and ("text" in mime_type or "json" in mime_type):
+                try:
+                    content_str = content.decode("utf-8", errors="replace")                            
+                    event["content"] = content_str
+                    
+                except:
+                    event["content"] = "<binary data>"
+            else:
+                event["content"] = (
+                    f"<binary data ({len(content)} bytes)>"
+                )
+            event["mime_type"] = mime_type
+    except Exception as e:
+        event["error_getting_response"] = str(e)    
+
+
+    if not XetrackParams.FLATTEN_RESPONSE:
+        return [event]
+        
+    events = []    
+    for content in event.pop("content", []):
+        content_event = event.copy()
+        for key, value in content.items():
+            content_event[f"content_{key}"] = value
+        
+        events.append(content_event)    
+    
+
+    return events
+
+class XetrackTracingPlugin(TracingPlugin):
+    """A plugin for Xetrack tracing."""
+
+    plugin_type = "tracing"
+    plugin_name = "xetrack"
+
+
+    def __init__(self):
+        self.db_path:str = XetrackParams.DB_PATH
+        self.logs_path:str|None = XetrackParams.LOGS_PATH
+        self.logs_stdout:bool = XetrackParams.LOGS_STDOUT
+        self.tracker:Tracker|None = None
+        
+
+    def load(self, config: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Loads configuration for the tracing plugin.
+
+        Configuration options:
+        - db_path: The path to the database file (default: Tracker.IN_MEMORY)
+        - logs_path: The path to the logs file (default: None)
+        - logs_stdout: Whether to log to stdout (default: False)
+        """
+        if config is None:
+            config = {}      
+        self.logs_path = config.get("logs_path", self.logs_path)
+        self.logs_stdout = config.get("logs_stdout", self.logs_stdout)
+        self.db_path = config.get("db_path", self.db_path)
+        self.tracker = Tracker(db=self.db_path, 
+                               logs_path=self.logs_path, 
+                               logs_stdout=self.logs_stdout, 
+                               log_system_params=False,
+                               log_network_params=False,
+                               logs_file_format=XetrackParams.LOG_FORMAT,
+                               warnings=XetrackParams.WARNINGS)
+        logger.info(
+            f"XetrackTracingPlugin loaded with db_path={self.db_path}, "
+            f"logs_path={self.logs_path}, logs_stdout={self.logs_stdout}"
+        )
+
+    def process_request(self, context: PluginContext) -> Optional[Dict[str, Any]]:
+        """Logs request data."""
+        # Tracing plugins don't modify the request
+        return context.arguments
+
+    def process_response(self, context: PluginContext) -> Any:
+        """Logs response data."""    
+        event: Dict[str, Any] = context.to_dict()
+        events = to_events(context, event)
+        for event in events:
+            self.tracker.log(event)
+        return context.response

--- a/mcp_gateway/plugins/tracing/xetrack.py
+++ b/mcp_gateway/plugins/tracing/xetrack.py
@@ -5,6 +5,8 @@ from xetrack import Tracker
 from xetrack.logging import LOGURU_PARAMS
 from mcp_gateway.plugins.base import TracingPlugin, PluginContext
 from uuid import uuid4
+from pathlib import Path
+import os
 logger = logging.getLogger(__name__)
 
 class XetrackParams:
@@ -119,6 +121,8 @@ class XetrackTracingPlugin(TracingPlugin):
         self.logs_path = config.get("logs_path", self.logs_path)
         self.logs_stdout = config.get("logs_stdout", self.logs_stdout)
         self.db_path = config.get("db_path", self.db_path)
+        # Fix duckdb sqlite externsion issue when home is not set
+        os.environ['HOME'] = Path.home().as_posix() 
         self.tracker = Tracker(db=self.db_path, 
                                logs_path=self.logs_path, 
                                logs_stdout=self.logs_stdout, 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ presidio = [
     "presidio-anonymizer>=2.2.0",
     "presidio-analyzer>=2.2.0",
 ]
+xetrack = [
+    "xetrack>=0.3.4",
+]
 
 [project.scripts]
 mcp-gateway = "mcp_gateway.server:main"

--- a/tests/xetrack_tracing_test.py
+++ b/tests/xetrack_tracing_test.py
@@ -6,9 +6,6 @@ from xetrack import Reader
 import os
 
 
-# TODO remove this
-temp_directory = TemporaryDirectory()
-
 @pytest.fixture(scope="module")
 def temp_directory():
     """

--- a/tests/xetrack_tracing_test.py
+++ b/tests/xetrack_tracing_test.py
@@ -1,0 +1,65 @@
+import pytest
+from mcp_gateway.plugins.tracing.xetrack import XetrackTracingPlugin
+from mcp_gateway.plugins.base import PluginContext
+from tempfile import TemporaryDirectory
+from xetrack import Reader
+import os
+
+
+# TODO remove this
+temp_directory = TemporaryDirectory()
+
+@pytest.fixture(scope="module")
+def temp_directory():
+    """
+    Fixture providing a temporary directory that persists for the module.
+    """
+    with TemporaryDirectory() as temp_dir:
+        yield temp_dir
+
+@pytest.fixture
+def plugin(temp_directory: str) -> XetrackTracingPlugin:
+    """
+    Fixture providing a configured XetrackTracingPlugin instance.
+    """    
+    
+    plugin = XetrackTracingPlugin()
+    # logs_path = 'logs'
+    logs_path = os.path.join(temp_directory, 'logs')
+    plugin.load({"logs_path": logs_path, "db_path": temp_directory+'/tests.db'})
+    return plugin
+
+def test_xetrack_tracing(plugin: XetrackTracingPlugin, temp_directory: str
+) -> None:
+    """
+    Test that the plugin properly processes responses and creates a valid database.
+    """
+    
+    mock_context = PluginContext(
+        server_name="test_server",
+        capability_type="test_capability",
+        capability_name="test_operation",
+        arguments={"path": "xdss/mcp-gateway"},
+        response={"_meta": None, 
+                  "content": [
+                      {"type": "text", "text": "[DIR] .cursor\n[DIR] .git\n[FILE] .gitignore\n[DIR] .pytest_cache\n[DIR] .venv\n[FILE] LICENSE\n[FILE] MANIFEST.in\n[FILE] README.md\n[DIR] docs\n[DIR] logs\n[DIR] mcp_gateway\n[DIR] mcp_gateway.egg-info\n[FILE] pyproject.toml\n[FILE] requirements.txt\n[DIR] tests", "annotations": None},
+                      {"type": "text", "text": "a response", "annotations": {"maybe this something":"else"}}
+                  ], 
+                  "isError": False}
+    )
+    
+    result = plugin.process_response(mock_context)    
+    assert '_meta' in result, "Result should have _meta"
+    assert 'content' in result, "Result should have content"
+    assert len(result['content']) == 2, "Result should have 2 content items"
+    
+        
+    db_path = os.path.join(temp_directory, 'tests.db')
+    assert os.path.exists(db_path), f"Database file not found at {db_path}"    
+    df = Reader(db=db_path).to_df()
+    assert len(df)==2 , "Database is empty"
+     
+    logs_path = os.listdir(os.path.join(temp_directory, 'logs'))[0]
+    with open(os.path.join(temp_directory, 'logs', logs_path), 'r') as f:        
+        assert len(f.readlines()) > 0, "Logs file is empty"
+    


### PR DESCRIPTION
### Xetrack
[xetrack](https://github.com/xdssio/xetrack) is a lightweight package to track ml experiments, benchmarks, and monitor stractured data.

We can use it to debug and monitor **tool calls** with logs ([loguru](https://github.com/Delgan/loguru)) or [duckdb](https://duckdb.org) and [sqlite](https://sqlite.org).   .

```bash
mcp-gateway --enable-tracing xetrack

```
#### Prerequisites
`pip install xetrack`

#### Params
* `XETRACK_DB_PATH` - The sqlite db location. 
    * All logs register in the *events* table.
    * If fancy objects return from the MCPs response, read about xetrack [assets](https://github.com/xdssio/xetrack?tab=readme-ov-file#track-assets-oriented-for-ml-models) to retrive it. 
* `XETRACK_LOGS_PATH` - The logs location
* `FLATTEN_ARGUMENTS` - Flatten the arguments, default `true`
* `FLATTEN_RESPONSE` - Flatten the response, default `true`
* It is recommend to to gitignore the logs location
* It is recommended to use [DVC](http://dvc.org) to manage the db file

#### Quickstart 
```json
{
    "mcpServers": {
        "mcp-gateway": {
            "command": "mcp-gateway",
            "args": [
                "--mcp-json-path",
                "~/development/xdss/mcp-gateway/.cursor/mcp.json",
                "--enable-tracing",
                "xetrack"
            ],
            "env": {
                "XETRACK_DB_PATH": "tracing.db",
                "XETRACK_LOGS_PATH": "logs/",                
            },
            "servers": {
                "filesystem": {
                    "command": "npx",
                    "args": [
                        "-y",
                        "@modelcontextprotocol/server-filesystem",
                        "."
                    ]
                }
            }
        }
    }
}
```

Let's say you use the  filesystem *list_directory* tool on path *"."*, you can find the call parameters under `logs/<date>.log`.

You can expolre using [xetrack cli](https://github.com/xdssio/xetrack?tab=readme-ov-file#cli) to query the db:

```bash
$ xt tail tracing.db --json --n=1
[
    {
        "timestamp": "2025-04-17 17:12:48.233126",
        "track_id": "mottled-stingray-0411",
        "meta": "f3be31e09667745f",
        "paths": null,
        "call_id": "deab617e-0a45-4950-9de9-3fb549810cf2",
        "capability_name": "list_directory",
        "content_type": "text",
        "content_annotations": "f3be31e09667745f",
        "response_type": "CallToolResult",
        "server_name": "filesystem",
        "capability_type": "tool",
        "isError": 0,
        "content_text": "[DIR] .cursor\n[DIR] .git\n[FILE] .gitignore\n[DIR] .pytest_cache\n[DIR] .venv\n[FILE] LICENSE\n[FILE] MANIFEST.in\n[FILE] README.md\n[DIR] docs\n[DIR] logs\n[DIR] mcp_gateway\n[FILE] pyproject.toml\n[FILE] requirements.txt\n[DIR] tests\n[DIR] tmp",
        "path": ".",
        "prompt": null
    }
]
```
With python
```python
from xetrack import Reader

df = Reader("tracing.db").to_df()
```


With duckdb cli and ui 
```bash
$ duckdb --ui
D INSTALL sqlite; LOAD sqlite; ATTACH 'tracing.db' (TYPE sqlite);
D SELECT server_name,capability_name,path,content_text FROM db.events LIMIT 1;

┌─────────────┬─────────────────┬─────────┬────────────────────────────────────┐
│ server_name │ capability_name │  path   │            content_text            │
│   varchar   │     varchar     │ varchar │              varchar               │
├─────────────┼─────────────────┼─────────┼────────────────────────────────────┤
│ filesystem  │ list_directory  │ .       │ [DIR] .cursor\n[DIR] .git\n[FILE…  │
└─────────────┴─────────────────┴─────────┴────────────────────────────────────┘
```

Of course you can use another MCP server to query the sqlite database 😊
