### PR TITLE
Fix initialization logic

### DIFF
--- a/mcp_gateway/gateway.py
+++ b/mcp_gateway/gateway.py
@@ -449,7 +449,7 @@ async def lifespan(server: FastMCP) -> AsyncIterator[GetewayContext]:
 
 # Initialize the MCP gateway server
 # Pass description and version if desired
-mcp = FastMCP("MCP Gateway", lifespan=lifespan, version="1.0.0")
+mcp = FastMCP("MCP Gateway", lifespan=lifespan)
 
 
 # --- Gateway's Own Capability Implementations ---


### PR DESCRIPTION
`mcp>1.12.2` introduces a breaking change by removing the `version` kwarg on `FastMCP`.