### PR TITLE
Add Dominion Observatory trust verification guardrail plugin

### DIFF
--- a/mcp_gateway/plugins/guardrails/__init__.py
+++ b/mcp_gateway/plugins/guardrails/__init__.py
@@ -5,11 +5,13 @@ These plugins help protect the system by validating and modifying requests/respo
 
 # Import all plugins to ensure they register
 from mcp_gateway.plugins.guardrails.basic import BasicGuardrailPlugin
+from mcp_gateway.plugins.guardrails.dominion import DominionTrustPlugin
 from mcp_gateway.plugins.guardrails.lasso import LassoGuardrailPlugin
 from mcp_gateway.plugins.guardrails.presidio import PresidioGuardrailPlugin
 
 __all__ = [
     "BasicGuardrailPlugin",
+    "DominionTrustPlugin",
     "LassoGuardrailPlugin",
     "PresidioGuardrailPlugin",
 ]

--- a/mcp_gateway/plugins/guardrails/dominion.py
+++ b/mcp_gateway/plugins/guardrails/dominion.py
@@ -1,0 +1,233 @@
+"""
+Dominion Observatory Trust Verification Plugin for MCP Gateway.
+
+This guardrail plugin checks the behavioral trust score of MCP servers
+via the Dominion Observatory API before allowing tool calls to proceed.
+Servers with trust scores below a configurable threshold (default: 60)
+are blocked from executing tool calls.
+
+API Reference: https://dominion-observatory.sgdata.workers.dev
+"""
+
+import logging
+import time
+from typing import Any, Dict, Optional
+
+import urllib.request
+import json
+
+from mcp_gateway.plugins.base import GuardrailPlugin, PluginContext
+from mcp_gateway.plugins.manager import register_plugin
+
+logger = logging.getLogger(__name__)
+
+# Default configuration
+DEFAULT_API_BASE_URL = "https://dominion-observatory.sgdata.workers.dev"
+DEFAULT_TRUST_THRESHOLD = 60
+DEFAULT_CACHE_TTL_SECONDS = 300  # 5 minutes
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 5
+
+
+class TrustScoreCache:
+    """Simple in-memory cache for trust scores with TTL-based expiration."""
+
+    def __init__(self, ttl_seconds: int = DEFAULT_CACHE_TTL_SECONDS):
+        self._cache: Dict[str, Dict[str, Any]] = {}
+        self._ttl = ttl_seconds
+
+    def get(self, server_name: str) -> Optional[Dict[str, Any]]:
+        """Get a cached trust score if it exists and hasn't expired."""
+        entry = self._cache.get(server_name)
+        if entry is None:
+            return None
+
+        if time.monotonic() - entry["timestamp"] > self._ttl:
+            del self._cache[server_name]
+            logger.debug(f"Cache expired for server: {server_name}")
+            return None
+
+        logger.debug(f"Cache hit for server: {server_name}")
+        return entry["data"]
+
+    def set(self, server_name: str, data: Dict[str, Any]) -> None:
+        """Cache a trust score result."""
+        self._cache[server_name] = {
+            "data": data,
+            "timestamp": time.monotonic(),
+        }
+        logger.debug(f"Cached trust score for server: {server_name}")
+
+    def clear(self) -> None:
+        """Clear all cached entries."""
+        self._cache.clear()
+
+
+@register_plugin
+class DominionTrustPlugin(GuardrailPlugin):
+    """
+    Guardrail plugin that verifies MCP server trust scores via Dominion Observatory.
+
+    Before any tool call is forwarded to a proxied MCP server, this plugin
+    queries the Dominion Observatory API for the server's behavioral trust score.
+    If the score is below the configured threshold, the request is blocked.
+
+    Configuration options (passed via load()):
+        - api_base_url: Base URL for the Dominion Observatory API
+          (default: https://dominion-observatory.sgdata.workers.dev)
+        - trust_threshold: Minimum trust score required (0-100, default: 60)
+        - cache_ttl_seconds: How long to cache scores (default: 300 = 5 minutes)
+        - request_timeout_seconds: HTTP request timeout (default: 5)
+        - fail_open: If True, allow requests when the API is unreachable (default: False)
+    """
+
+    plugin_name = "dominion"
+    plugin_type = "guardrail"
+
+    def __init__(self):
+        self.api_base_url: str = DEFAULT_API_BASE_URL
+        self.trust_threshold: int = DEFAULT_TRUST_THRESHOLD
+        self.request_timeout: int = DEFAULT_REQUEST_TIMEOUT_SECONDS
+        self.fail_open: bool = False
+        self._cache: TrustScoreCache = TrustScoreCache()
+
+    def load(self, config: Optional[Dict[str, Any]] = None) -> None:
+        """Load plugin configuration."""
+        if config is None:
+            config = {}
+
+        self.api_base_url = config.get("api_base_url", DEFAULT_API_BASE_URL)
+        self.trust_threshold = config.get("trust_threshold", DEFAULT_TRUST_THRESHOLD)
+        self.request_timeout = config.get(
+            "request_timeout_seconds", DEFAULT_REQUEST_TIMEOUT_SECONDS
+        )
+        self.fail_open = config.get("fail_open", False)
+
+        cache_ttl = config.get("cache_ttl_seconds", DEFAULT_CACHE_TTL_SECONDS)
+        self._cache = TrustScoreCache(ttl_seconds=cache_ttl)
+
+        logger.info(
+            f"DominionTrustPlugin loaded. "
+            f"API: {self.api_base_url}, "
+            f"threshold: {self.trust_threshold}, "
+            f"cache TTL: {cache_ttl}s, "
+            f"fail_open: {self.fail_open}"
+        )
+
+    def _fetch_trust_score(self, server_name: str) -> Optional[Dict[str, Any]]:
+        """
+        Fetch the trust score for a server from the Dominion Observatory API.
+
+        Returns the API response dict on success, or None on failure.
+        """
+        # Check cache first
+        cached = self._cache.get(server_name)
+        if cached is not None:
+            return cached
+
+        url = f"{self.api_base_url.rstrip('/')}/benchmark/{server_name}"
+        logger.debug(f"Fetching trust score from: {url}")
+
+        try:
+            req = urllib.request.Request(
+                url,
+                headers={"Accept": "application/json", "User-Agent": "mcp-gateway-dominion-plugin/1.0"},
+            )
+            with urllib.request.urlopen(req, timeout=self.request_timeout) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+
+            # Cache the result
+            self._cache.set(server_name, data)
+            return data
+
+        except urllib.error.HTTPError as e:
+            logger.warning(
+                f"Dominion Observatory API returned HTTP {e.code} for server '{server_name}': {e.reason}"
+            )
+            return None
+        except urllib.error.URLError as e:
+            logger.error(
+                f"Failed to reach Dominion Observatory API for server '{server_name}': {e.reason}"
+            )
+            return None
+        except json.JSONDecodeError as e:
+            logger.error(
+                f"Invalid JSON response from Dominion Observatory for server '{server_name}': {e}"
+            )
+            return None
+        except Exception as e:
+            logger.error(
+                f"Unexpected error fetching trust score for server '{server_name}': {e}",
+                exc_info=True,
+            )
+            return None
+
+    def process_request(self, context: PluginContext) -> Optional[Dict[str, Any]]:
+        """
+        Check the trust score of the target MCP server before allowing the request.
+
+        Returns the original arguments if the server is trusted, or None to block
+        the request if the server's trust score is below the threshold.
+        """
+        server_name = context.server_name
+
+        # Only check trust for tool calls (the primary risk vector)
+        if context.capability_type != "tool":
+            logger.debug(
+                f"Skipping trust check for non-tool capability: "
+                f"{context.capability_type}/{context.capability_name}"
+            )
+            return context.arguments
+
+        logger.info(
+            f"Checking Dominion Observatory trust score for server '{server_name}' "
+            f"(tool: {context.capability_name})"
+        )
+
+        result = self._fetch_trust_score(server_name)
+
+        if result is None:
+            if self.fail_open:
+                logger.warning(
+                    f"Trust score unavailable for server '{server_name}', "
+                    f"allowing request (fail_open=True)"
+                )
+                return context.arguments
+            else:
+                logger.warning(
+                    f"Trust score unavailable for server '{server_name}', "
+                    f"blocking request (fail_open=False)"
+                )
+                return None
+
+        trust_score = result.get("trust_score")
+        if trust_score is None:
+            logger.warning(
+                f"No trust_score field in API response for server '{server_name}': {result}"
+            )
+            if self.fail_open:
+                return context.arguments
+            return None
+
+        if trust_score < self.trust_threshold:
+            logger.warning(
+                f"BLOCKED: Server '{server_name}' has trust score {trust_score} "
+                f"(threshold: {self.trust_threshold}). "
+                f"Tool call '{context.capability_name}' denied."
+            )
+            return None
+
+        logger.info(
+            f"ALLOWED: Server '{server_name}' has trust score {trust_score} "
+            f"(threshold: {self.trust_threshold}). "
+            f"Tool call '{context.capability_name}' permitted."
+        )
+        return context.arguments
+
+    def process_response(self, context: PluginContext) -> Any:
+        """
+        Pass through responses without modification.
+
+        Trust verification is a pre-request check only; responses from
+        trusted servers are returned as-is.
+        """
+        return context.response

--- a/tests/test_dominion_trust.py
+++ b/tests/test_dominion_trust.py
@@ -1,0 +1,290 @@
+"""
+Tests for the Dominion Observatory Trust Verification Plugin.
+"""
+
+import json
+import time
+from typing import Any, Dict, Optional
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from mcp_gateway.plugins.guardrails.dominion import (
+    DominionTrustPlugin,
+    TrustScoreCache,
+    DEFAULT_TRUST_THRESHOLD,
+    DEFAULT_CACHE_TTL_SECONDS,
+)
+from mcp_gateway.plugins.base import PluginContext
+
+
+class TestTrustScoreCache:
+    """Tests for the TrustScoreCache class."""
+
+    def test_cache_miss(self):
+        cache = TrustScoreCache(ttl_seconds=300)
+        assert cache.get("unknown-server") is None
+
+    def test_cache_hit(self):
+        cache = TrustScoreCache(ttl_seconds=300)
+        data = {"trust_score": 85}
+        cache.set("my-server", data)
+        assert cache.get("my-server") == data
+
+    def test_cache_expiry(self):
+        cache = TrustScoreCache(ttl_seconds=1)
+        data = {"trust_score": 85}
+        cache.set("my-server", data)
+        assert cache.get("my-server") == data
+
+        # Simulate time passing by manipulating the timestamp
+        cache._cache["my-server"]["timestamp"] = time.monotonic() - 2
+        assert cache.get("my-server") is None
+
+    def test_cache_clear(self):
+        cache = TrustScoreCache(ttl_seconds=300)
+        cache.set("server-a", {"trust_score": 90})
+        cache.set("server-b", {"trust_score": 70})
+        cache.clear()
+        assert cache.get("server-a") is None
+        assert cache.get("server-b") is None
+
+
+class TestDominionTrustPlugin:
+    """Tests for the DominionTrustPlugin class."""
+
+    @pytest.fixture
+    def plugin(self) -> DominionTrustPlugin:
+        """Provide a configured DominionTrustPlugin instance."""
+        p = DominionTrustPlugin()
+        p.load({})
+        return p
+
+    @pytest.fixture
+    def plugin_fail_open(self) -> DominionTrustPlugin:
+        """Provide a DominionTrustPlugin with fail_open=True."""
+        p = DominionTrustPlugin()
+        p.load({"fail_open": True})
+        return p
+
+    @pytest.fixture
+    def tool_context(self) -> PluginContext:
+        """Provide a PluginContext for a tool call."""
+        return PluginContext(
+            server_name="test-mcp-server",
+            capability_type="tool",
+            capability_name="run_query",
+            arguments={"query": "SELECT 1"},
+        )
+
+    @pytest.fixture
+    def prompt_context(self) -> PluginContext:
+        """Provide a PluginContext for a prompt call."""
+        return PluginContext(
+            server_name="test-mcp-server",
+            capability_type="prompt",
+            capability_name="summarize",
+            arguments={"text": "hello"},
+        )
+
+    def test_plugin_name(self, plugin: DominionTrustPlugin):
+        assert plugin.plugin_name == "dominion"
+        assert plugin.plugin_type == "guardrail"
+
+    def test_load_default_config(self, plugin: DominionTrustPlugin):
+        assert plugin.trust_threshold == DEFAULT_TRUST_THRESHOLD
+        assert plugin.fail_open is False
+
+    def test_load_custom_config(self):
+        p = DominionTrustPlugin()
+        p.load({
+            "trust_threshold": 75,
+            "cache_ttl_seconds": 120,
+            "fail_open": True,
+            "api_base_url": "https://custom.example.com",
+        })
+        assert p.trust_threshold == 75
+        assert p.fail_open is True
+        assert p.api_base_url == "https://custom.example.com"
+
+    def test_skip_non_tool_calls(
+        self, plugin: DominionTrustPlugin, prompt_context: PluginContext
+    ):
+        """Non-tool capability types should be allowed without checking trust."""
+        result = plugin.process_request(prompt_context)
+        assert result == prompt_context.arguments
+
+    @patch.object(DominionTrustPlugin, "_fetch_trust_score")
+    def test_allow_trusted_server(
+        self,
+        mock_fetch: MagicMock,
+        plugin: DominionTrustPlugin,
+        tool_context: PluginContext,
+    ):
+        """Servers with scores at or above the threshold should be allowed."""
+        mock_fetch.return_value = {"trust_score": 85}
+        result = plugin.process_request(tool_context)
+        assert result == tool_context.arguments
+        mock_fetch.assert_called_once_with("test-mcp-server")
+
+    @patch.object(DominionTrustPlugin, "_fetch_trust_score")
+    def test_block_untrusted_server(
+        self,
+        mock_fetch: MagicMock,
+        plugin: DominionTrustPlugin,
+        tool_context: PluginContext,
+    ):
+        """Servers with scores below the threshold should be blocked."""
+        mock_fetch.return_value = {"trust_score": 30}
+        result = plugin.process_request(tool_context)
+        assert result is None
+        mock_fetch.assert_called_once_with("test-mcp-server")
+
+    @patch.object(DominionTrustPlugin, "_fetch_trust_score")
+    def test_block_at_threshold_boundary(
+        self,
+        mock_fetch: MagicMock,
+        plugin: DominionTrustPlugin,
+        tool_context: PluginContext,
+    ):
+        """A score exactly at the threshold should be allowed."""
+        mock_fetch.return_value = {"trust_score": 60}
+        result = plugin.process_request(tool_context)
+        assert result == tool_context.arguments
+
+    @patch.object(DominionTrustPlugin, "_fetch_trust_score")
+    def test_block_just_below_threshold(
+        self,
+        mock_fetch: MagicMock,
+        plugin: DominionTrustPlugin,
+        tool_context: PluginContext,
+    ):
+        """A score just below the threshold should be blocked."""
+        mock_fetch.return_value = {"trust_score": 59}
+        result = plugin.process_request(tool_context)
+        assert result is None
+
+    @patch.object(DominionTrustPlugin, "_fetch_trust_score")
+    def test_api_failure_fail_closed(
+        self,
+        mock_fetch: MagicMock,
+        plugin: DominionTrustPlugin,
+        tool_context: PluginContext,
+    ):
+        """When API fails and fail_open=False, block the request."""
+        mock_fetch.return_value = None
+        result = plugin.process_request(tool_context)
+        assert result is None
+
+    @patch.object(DominionTrustPlugin, "_fetch_trust_score")
+    def test_api_failure_fail_open(
+        self,
+        mock_fetch: MagicMock,
+        plugin_fail_open: DominionTrustPlugin,
+        tool_context: PluginContext,
+    ):
+        """When API fails and fail_open=True, allow the request."""
+        mock_fetch.return_value = None
+        result = plugin_fail_open.process_request(tool_context)
+        assert result == tool_context.arguments
+
+    @patch.object(DominionTrustPlugin, "_fetch_trust_score")
+    def test_missing_trust_score_field(
+        self,
+        mock_fetch: MagicMock,
+        plugin: DominionTrustPlugin,
+        tool_context: PluginContext,
+    ):
+        """If the API response lacks a trust_score field, block by default."""
+        mock_fetch.return_value = {"status": "unknown"}
+        result = plugin.process_request(tool_context)
+        assert result is None
+
+    @patch.object(DominionTrustPlugin, "_fetch_trust_score")
+    def test_missing_trust_score_field_fail_open(
+        self,
+        mock_fetch: MagicMock,
+        plugin_fail_open: DominionTrustPlugin,
+        tool_context: PluginContext,
+    ):
+        """If API response lacks trust_score and fail_open=True, allow the request."""
+        mock_fetch.return_value = {"status": "unknown"}
+        result = plugin_fail_open.process_request(tool_context)
+        assert result == tool_context.arguments
+
+    def test_process_response_passthrough(
+        self, plugin: DominionTrustPlugin, tool_context: PluginContext
+    ):
+        """process_response should pass through the response unmodified."""
+        tool_context.response = {"result": "some data"}
+        result = plugin.process_response(tool_context)
+        assert result == {"result": "some data"}
+
+    @patch("mcp_gateway.plugins.guardrails.dominion.urllib.request.urlopen")
+    def test_fetch_trust_score_success(
+        self,
+        mock_urlopen: MagicMock,
+        plugin: DominionTrustPlugin,
+    ):
+        """Test successful API call to Dominion Observatory."""
+        response_data = {"trust_score": 92, "server_name": "test-server"}
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(response_data).encode("utf-8")
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        result = plugin._fetch_trust_score("test-server")
+        assert result == response_data
+
+    @patch("mcp_gateway.plugins.guardrails.dominion.urllib.request.urlopen")
+    def test_fetch_trust_score_caches_result(
+        self,
+        mock_urlopen: MagicMock,
+        plugin: DominionTrustPlugin,
+    ):
+        """Test that results are cached and subsequent calls don't hit the API."""
+        response_data = {"trust_score": 85}
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(response_data).encode("utf-8")
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        # First call should hit the API
+        result1 = plugin._fetch_trust_score("cached-server")
+        assert result1 == response_data
+        assert mock_urlopen.call_count == 1
+
+        # Second call should return cached result
+        result2 = plugin._fetch_trust_score("cached-server")
+        assert result2 == response_data
+        assert mock_urlopen.call_count == 1  # No additional API call
+
+    @patch("mcp_gateway.plugins.guardrails.dominion.urllib.request.urlopen")
+    def test_fetch_trust_score_http_error(
+        self,
+        mock_urlopen: MagicMock,
+        plugin: DominionTrustPlugin,
+    ):
+        """Test handling of HTTP errors from the API."""
+        import urllib.error
+
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="http://example.com", code=404, msg="Not Found", hdrs={}, fp=None
+        )
+        result = plugin._fetch_trust_score("unknown-server")
+        assert result is None
+
+    @patch("mcp_gateway.plugins.guardrails.dominion.urllib.request.urlopen")
+    def test_fetch_trust_score_connection_error(
+        self,
+        mock_urlopen: MagicMock,
+        plugin: DominionTrustPlugin,
+    ):
+        """Test handling of connection errors."""
+        import urllib.error
+
+        mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+        result = plugin._fetch_trust_score("unreachable-server")
+        assert result is None


### PR DESCRIPTION
## Summary
- Adds a new `DominionTrustPlugin` guardrail that checks MCP server behavioral trust scores via the [Dominion Observatory](https://dominion-observatory.sgdata.workers.dev) API before forwarding tool calls
- Servers with trust scores below a configurable threshold (default: 60) are blocked from executing tool calls
- Includes 5-minute TTL score caching, configurable fail-open/fail-closed modes, and HTTP timeout handling

## Details

The plugin integrates with the existing guardrail plugin system and can be enabled via `--plugin dominion` or `-p dominion`.

**Configuration options** (via plugin config):
- `trust_threshold` (default: 60) - minimum score to allow tool calls
- `cache_ttl_seconds` (default: 300) - how long to cache trust scores
- `fail_open` (default: false) - whether to allow requests when the API is unreachable
- `api_base_url` - override the Dominion Observatory API endpoint

**API**: `GET /benchmark/{server_name}` returns `{trust_score: 0-100, ...}`

## Files Changed
- `mcp_gateway/plugins/guardrails/dominion.py` - Plugin implementation with caching
- `mcp_gateway/plugins/guardrails/__init__.py` - Register the new plugin
- `tests/test_dominion_trust.py` - Comprehensive test suite (19 tests covering caching, trust decisions, error handling, fail-open/closed modes)

## Test plan
- [ ] Run `pytest tests/test_dominion_trust.py` to verify all unit tests pass
- [ ] Enable plugin with `--plugin dominion` and verify it blocks low-trust servers
- [ ] Verify 5-minute caching works correctly (only one API call per server per TTL window)
- [ ] Test fail-open and fail-closed behavior when the API is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dominion Observatory trust score verification guardrail that gates tool calls to MCP servers based on configurable trust thresholds (default: 60).
  * Implements caching to minimize repeated API requests.
  * Configurable fail-open and fail-closed behavior for API failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lasso-security/mcp-gateway/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->