### PR TITLE
feat: add observe-only MCP Fingerprint lifecycle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,33 @@ MCP Gateway supports various plugins to enhance security and functionality. Here
 
 **Note:** To use the `presidio` plugin, you need to install it separately: `pip install mcp-gateway[presidio]`.
 
+## MCP Fingerprint (observe-only)
+
+Install the optional dependency on supported Python (3.12.x):
+
+```bash
+pip install "mcp-gateway[fingerprint]"
+```
+
+Enable observe-only contract fingerprinting at proxied server startup:
+
+```bash
+mcp-gateway --mcp-json-path ~/.cursor/mcp.json -p mcp-fingerprint
+```
+
+Bootstrap missing baselines without overwriting existing files:
+
+```bash
+mcp-gateway --mcp-json-path ~/.cursor/mcp.json -p mcp-fingerprint --fingerprint-bootstrap
+```
+
+Options:
+
+- `--fingerprint-baseline-dir DIR` — baseline directory (default: `.mcp-fingerprint`)
+- `--fingerprint-bootstrap` — create missing baselines only; never overwrite existing baselines
+
+v1 has no runtime `listChanged` support. Restart the gateway to re-check tool contracts against saved baselines. Fingerprint status is logged only and never blocks startup, tool registration, or tool calls.
+
 
 ### Basic 
 ```bash

--- a/mcp_gateway/gateway.py
+++ b/mcp_gateway/gateway.py
@@ -371,9 +371,23 @@ async def lifespan(server: FastMCP) -> AsyncIterator[GetewayContext]:
     else:
         logger.info("Tracing plugins DISABLED.")
 
+    if "lifecycle" in enabled_plugin_types:
+        logger.info(f"Lifecycle plugins ENABLED: {enabled_plugins.get('lifecycle', [])}")
+    else:
+        logger.info("Lifecycle plugins DISABLED.")
+
+    plugin_configs: Dict[str, Dict[str, Any]] = {}
+    if cli_args and "mcp-fingerprint" in cli_args.plugin:
+        plugin_configs["mcp-fingerprint"] = {
+            "baseline_dir": cli_args.fingerprint_baseline_dir,
+            "bootstrap": cli_args.fingerprint_bootstrap,
+        }
+
     # Initialize plugin manager with configuration
     plugin_manager = PluginManager(
-        enabled_types=enabled_plugin_types, enabled_plugins=enabled_plugins
+        enabled_types=enabled_plugin_types,
+        enabled_plugins=enabled_plugins,
+        plugin_configs=plugin_configs,
     )
 
     # Load proxied server configs
@@ -426,6 +440,13 @@ async def lifespan(server: FastMCP) -> AsyncIterator[GetewayContext]:
         logger.warning(
             "No proxied MCP servers configured. Running in standalone mode (plugins still active)."
         )
+
+    # Observe-only lifecycle hooks after capability acquisition, before registration.
+    for server_name, proxied_server in context.proxied_servers.items():
+        if proxied_server.session:
+            await plugin_manager.notify_server_capabilities_ready(
+                server_name, proxied_server
+            )
 
     # Register capabilities from proxied servers
     await register_proxied_capabilities(server, context)
@@ -587,6 +608,20 @@ def parse_args(args=None):
         "--scan",
         action="store_true",
         help="Enable security scanner.",
+    )
+    parser.add_argument(
+        "--fingerprint-baseline-dir",
+        type=str,
+        default=".mcp-fingerprint",
+        help="Directory for mcp-fingerprint baseline files (default: .mcp-fingerprint).",
+    )
+    parser.add_argument(
+        "--fingerprint-bootstrap",
+        action="store_true",
+        help=(
+            "Create missing mcp-fingerprint baselines without overwriting existing files. "
+            "Gateway restart re-checks in observe mode."
+        ),
     )
     if args is None:
         args = sys.argv[1:]

--- a/mcp_gateway/plugins/__init__.py
+++ b/mcp_gateway/plugins/__init__.py
@@ -7,6 +7,7 @@ from mcp_gateway.plugins.base import (
     Plugin,
     PluginContext,
     GuardrailPlugin,
+    LifecyclePlugin,
     TracingPlugin,
 )
 from mcp_gateway.plugins.manager import PluginManager, register_plugin
@@ -15,6 +16,7 @@ __all__ = [
     "Plugin",
     "PluginContext",
     "GuardrailPlugin",
+    "LifecyclePlugin",
     "TracingPlugin",
     "PluginManager",
     "register_plugin",

--- a/mcp_gateway/plugins/base.py
+++ b/mcp_gateway/plugins/base.py
@@ -108,6 +108,24 @@ class GuardrailPlugin(Plugin, abc.ABC):
 
 
 
+class LifecyclePlugin(Plugin, abc.ABC):
+    """Minimal lifecycle hook for observe-only plugins at capability readiness."""
+
+    plugin_type = "lifecycle"
+
+    def process_request(self, context: PluginContext) -> Optional[Dict[str, Any]]:
+        return context.arguments
+
+    def process_response(self, context: PluginContext) -> Any:
+        return context.response
+
+    def on_server_capabilities_ready(
+        self, server_name: str, proxied_server: Any
+    ) -> None:
+        """Called after initial tools/list contract is available for a proxied server."""
+        pass
+
+
 class TracingPlugin(Plugin, abc.ABC):
     """Abstract base class for Tracing plugins (logging, monitoring)."""
 

--- a/mcp_gateway/plugins/lifecycle/__init__.py
+++ b/mcp_gateway/plugins/lifecycle/__init__.py
@@ -1,0 +1,5 @@
+"""Lifecycle plugins for MCP Gateway observe-only hooks."""
+
+from mcp_gateway.plugins.lifecycle.mcp_fingerprint import McpFingerprintPlugin
+
+__all__ = ["McpFingerprintPlugin"]

--- a/mcp_gateway/plugins/lifecycle/mcp_fingerprint.py
+++ b/mcp_gateway/plugins/lifecycle/mcp_fingerprint.py
@@ -1,0 +1,221 @@
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from mcp_gateway.plugins.base import LifecyclePlugin
+from mcp_gateway.plugins.manager import register_plugin
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASELINE_DIR = ".mcp-fingerprint"
+FINGERPRINT_PYTHON_MIN = (3, 12)
+FINGERPRINT_PYTHON_MAX = (3, 13)
+_SAVE_REQUEST_SCHEMA = "mcp.fingerprint.save.request.v0.1"
+_CHECK_REQUEST_SCHEMA = "mcp.fingerprint.check.request.v0.1"
+_SANITIZE_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def fingerprint_supported() -> bool:
+    """Return True when this Python runtime can use mcp-fingerprint."""
+    version = sys.version_info[:2]
+    return version >= FINGERPRINT_PYTHON_MIN and version < FINGERPRINT_PYTHON_MAX
+
+
+def resolve_baseline_path(*, server_name: str, baseline_dir: str) -> str:
+    """Resolve per-server baseline path under the configured directory."""
+    cleaned = _SANITIZE_RE.sub("-", server_name.strip()).strip(".-_")
+    if cleaned == "":
+        cleaned = "server"
+    return str(Path(baseline_dir) / f"{cleaned}.json")
+
+
+@register_plugin
+class McpFingerprintPlugin(LifecyclePlugin):
+    """Observe-only MCP tool-contract fingerprinting at capability readiness.
+
+    v1 has no runtime listChanged support; restart the gateway to re-check.
+    """
+
+    plugin_name = "mcp-fingerprint"
+
+    def __init__(self) -> None:
+        self._enabled = False
+        self._baseline_dir = DEFAULT_BASELINE_DIR
+        self._bootstrap = False
+        self._project_live_snapshot = None
+        self._save = None
+        self._check = None
+
+    def load(self, config: Optional[Dict[str, Any]] = None) -> None:
+        if config is None:
+            config = {}
+
+        self._baseline_dir = config.get("baseline_dir", DEFAULT_BASELINE_DIR)
+        self._bootstrap = bool(config.get("bootstrap", False))
+
+        if not fingerprint_supported():
+            logger.warning(
+                "mcp-fingerprint plugin disabled: requires Python "
+                f">={FINGERPRINT_PYTHON_MIN[0]}.{FINGERPRINT_PYTHON_MIN[1]} "
+                f"and <{FINGERPRINT_PYTHON_MAX[0]}.{FINGERPRINT_PYTHON_MAX[1]}"
+            )
+            self._enabled = False
+            return
+
+        try:
+            from mcp_fingerprint import check, project_live_snapshot, save
+        except ImportError:
+            logger.warning(
+                "mcp-fingerprint plugin disabled: install with "
+                "'pip install \"mcp-gateway[fingerprint]\"'"
+            )
+            self._enabled = False
+            return
+
+        self._project_live_snapshot = project_live_snapshot
+        self._save = save
+        self._check = check
+        self._enabled = True
+        mode = "bootstrap" if self._bootstrap else "observe"
+        logger.info(
+            "mcp-fingerprint plugin enabled (%s mode, baseline_dir=%s)",
+            mode,
+            self._baseline_dir,
+        )
+
+    def on_server_capabilities_ready(
+        self, server_name: str, proxied_server: Any
+    ) -> None:
+        if not self._enabled:
+            return
+
+        try:
+            snapshot = self._build_snapshot(proxied_server)
+        except Exception as exc:
+            self._log_observation_error(
+                server_name,
+                f"snapshot projection failed: {exc}",
+            )
+            return
+
+        baseline_path = resolve_baseline_path(
+            server_name=server_name,
+            baseline_dir=self._baseline_dir,
+        )
+
+        if self._bootstrap:
+            self._observe_bootstrap(server_name, snapshot, baseline_path)
+        else:
+            self._observe_check(server_name, snapshot, baseline_path)
+
+    def _build_snapshot(self, proxied_server: Any) -> Dict[str, Any]:
+        server_info = proxied_server._server_info
+        if server_info is None or server_info.serverInfo is None:
+            raise ValueError("server initialize result unavailable")
+
+        server = {
+            "name": server_info.serverInfo.name,
+            "version": server_info.serverInfo.version,
+        }
+        tools = [tool.model_dump(mode="json") for tool in proxied_server._tools]
+        return self._project_live_snapshot(server=server, tools=tools)
+
+    def _observe_bootstrap(
+        self, server_name: str, snapshot: Dict[str, Any], baseline_path: str
+    ) -> None:
+        result = self._save(
+            {
+                "schema_version": _SAVE_REQUEST_SCHEMA,
+                "snapshot": snapshot,
+                "baseline_path": baseline_path,
+            }
+        )
+        if result.get("ok") is True:
+            logger.info(
+                "mcp-fingerprint [%s]: baseline created at %s (fingerprint=%s)",
+                server_name,
+                baseline_path,
+                result.get("fingerprint"),
+            )
+            return
+
+        failure = result.get("failure") or {}
+        code = failure.get("code", "UNKNOWN")
+        if code == "BASELINE_ALREADY_EXISTS":
+            logger.info(
+                "mcp-fingerprint [%s]: bootstrap skipped; baseline already exists at %s",
+                server_name,
+                baseline_path,
+            )
+            return
+
+        self._log_observation_error(
+            server_name,
+            f"bootstrap failed ({code}): {failure.get('message', 'unknown error')}",
+        )
+
+    def _observe_check(
+        self, server_name: str, snapshot: Dict[str, Any], baseline_path: str
+    ) -> None:
+        if not Path(baseline_path).is_file():
+            self._log_observation_error(
+                server_name,
+                f"baseline missing at {baseline_path}",
+                code="BASELINE_NOT_FOUND",
+            )
+            return
+
+        result = self._check(
+            {
+                "schema_version": _CHECK_REQUEST_SCHEMA,
+                "snapshot": snapshot,
+                "baseline_path": baseline_path,
+            }
+        )
+        if result.get("ok") is not True:
+            failure = result.get("failure") or {}
+            code = failure.get("code", "UNKNOWN")
+            self._log_observation_error(
+                server_name,
+                f"check failed ({code}): {failure.get('message', 'unknown error')}",
+                code=code,
+            )
+            return
+
+        status = result.get("status")
+        if status == "UNCHANGED":
+            logger.info(
+                "mcp-fingerprint [%s]: UNCHANGED (baseline=%s, fingerprint=%s)",
+                server_name,
+                baseline_path,
+                result.get("fingerprint"),
+            )
+            return
+
+        if status == "CHANGED":
+            changes = result.get("changes") or []
+            logger.warning(
+                "mcp-fingerprint [%s]: CHANGED (baseline=%s, fingerprint=%s, changes=%s)",
+                server_name,
+                baseline_path,
+                result.get("fingerprint"),
+                changes,
+            )
+            return
+
+        self._log_observation_error(
+            server_name,
+            f"unexpected check status: {status!r}",
+        )
+
+    def _log_observation_error(
+        self, server_name: str, message: str, code: str = "OBSERVATION_ERROR"
+    ) -> None:
+        logger.error(
+            "mcp-fingerprint [%s]: observation error (%s): %s",
+            server_name,
+            code,
+            message,
+        )

--- a/mcp_gateway/plugins/manager.py
+++ b/mcp_gateway/plugins/manager.py
@@ -6,6 +6,7 @@ from mcp_gateway.plugins.base import (
     Plugin,
     PluginContext,
     GuardrailPlugin,
+    LifecyclePlugin,
     TracingPlugin,
 )
 
@@ -17,6 +18,7 @@ PluginT = TypeVar("PluginT", bound=Plugin)
 # Plugin registry to store all registered plugins
 _PLUGIN_REGISTRY: Dict[str, List[Type[Plugin]]] = {
     GuardrailPlugin.plugin_type: [],
+    LifecyclePlugin.plugin_type: [],
     TracingPlugin.plugin_type: [],
 }
 
@@ -88,6 +90,7 @@ def discover_plugins():
     # The __init__.py files should already import all plugin modules
     try:
         import mcp_gateway.plugins.guardrails
+        import mcp_gateway.plugins.lifecycle
         import mcp_gateway.plugins.tracing
 
         logger.info(f"Discovered {len(_PLUGIN_NAME_TO_INFO)} plugins")
@@ -126,6 +129,7 @@ class PluginManager:
         self,
         enabled_types: Optional[List[str]] = None,
         enabled_plugins: Optional[Dict[str, List[str]]] = None,
+        plugin_configs: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> None:
         """Initializes the PluginManager with configured plugins.
 
@@ -141,6 +145,7 @@ class PluginManager:
 
         self.enabled_types = enabled_types or []
         self.enabled_plugins = enabled_plugins or {}
+        self.plugin_configs = plugin_configs or {}
 
         # Dictionary to store instantiated plugin objects
         self._plugins: Dict[str, List[Plugin]] = {}
@@ -195,7 +200,12 @@ class PluginManager:
                 # Instantiate and load the plugin
                 try:
                     plugin_instance = plugin_cls()
-                    plugin_instance.load({})  # Empty config by default
+                    config = (
+                        self.plugin_configs.get(plugin_attr_name)
+                        or self.plugin_configs.get(plugin_name)
+                        or {}
+                    )
+                    plugin_instance.load(config)
                     self._plugins[plugin_type].append(plugin_instance)
                     logger.info(
                         f"Loaded plugin: {plugin_cls.__name__} (type: {plugin_type})"
@@ -336,3 +346,22 @@ class PluginManager:
                 )
 
         return current_response
+
+    async def notify_server_capabilities_ready(
+        self, server_name: str, proxied_server: Any
+    ) -> None:
+        """Notify lifecycle plugins that a proxied server's contract is ready."""
+        for plugin in self.get_plugins(LifecyclePlugin.plugin_type):
+            try:
+                if inspect.iscoroutinefunction(plugin.on_server_capabilities_ready):
+                    await plugin.on_server_capabilities_ready(
+                        server_name, proxied_server
+                    )
+                else:
+                    plugin.on_server_capabilities_ready(server_name, proxied_server)
+            except Exception as e:
+                logger.error(
+                    f"Error in lifecycle plugin {plugin.__class__.__name__} "
+                    f"for server '{server_name}': {e}",
+                    exc_info=True,
+                )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ presidio = [
 xetrack = [
     "xetrack>=0.3.4",
 ]
+fingerprint = [
+    "mcp-fingerprint>=0.2.1; python_version >= '3.12' and python_version < '3.13'",
+]
 
 [project.scripts]
 mcp-gateway = "mcp_gateway.server:main"
@@ -52,6 +55,9 @@ exclude = ["data*", "front*", "tests*"]
 
 [tool.setuptools.package-data]
 "*" = ["docs/*.png"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [dependency-groups]
 dev = [

--- a/tests/fixtures/minimal_stdio_server.py
+++ b/tests/fixtures/minimal_stdio_server.py
@@ -1,0 +1,21 @@
+"""Minimal stdio MCP server fixture for gateway integration tests."""
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("fixture-server")
+
+
+@mcp.tool()
+def echo(message: str) -> str:
+    """Echo the input message."""
+    return message
+
+
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    """Add two integers."""
+    return a + b
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/test_mcp_fingerprint_plugin.py
+++ b/tests/test_mcp_fingerprint_plugin.py
@@ -1,0 +1,514 @@
+"""Integration tests for observe-only mcp-fingerprint lifecycle plugin."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+from mcp import types
+
+from mcp_gateway.plugins.lifecycle.mcp_fingerprint import (
+    DEFAULT_BASELINE_DIR,
+    McpFingerprintPlugin,
+    fingerprint_supported,
+    resolve_baseline_path,
+)
+from mcp_gateway.plugins.manager import PluginManager
+from mcp_gateway.server import Server
+
+FIXTURE_SERVER = str(
+    Path(__file__).resolve().parent / "fixtures" / "minimal_stdio_server.py"
+)
+
+
+def _write_gateway_config(path: Path, servers: Dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "mcp-gateway": {
+                        "command": "mcp-gateway",
+                        "args": [],
+                        "servers": servers,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class _StubServer:
+    """Minimal stand-in for Server with initialize result and cached tools."""
+
+    def __init__(
+        self,
+        *,
+        name: str = "fixture-server",
+        version: str = "0.1.0",
+        tools: List[types.Tool] | None = None,
+    ) -> None:
+        self._server_info = types.InitializeResult(
+            protocolVersion="2024-11-05",
+            capabilities=types.ServerCapabilities(tools={}),
+            serverInfo=types.Implementation(name=name, version=version),
+        )
+        self._tools = tools or [
+            types.Tool(
+                name="echo",
+                description="Echo the input message.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"message": {"type": "string"}},
+                    "required": ["message"],
+                },
+            )
+        ]
+
+
+@pytest.fixture
+def baseline_dir(tmp_path: Path) -> Path:
+    return tmp_path / "baselines"
+
+
+@pytest.fixture
+def plugin(baseline_dir: Path) -> McpFingerprintPlugin:
+    plugin = McpFingerprintPlugin()
+    plugin.load(
+        {
+            "baseline_dir": str(baseline_dir),
+            "bootstrap": False,
+        }
+    )
+    return plugin
+
+
+@pytest.fixture
+def bootstrap_plugin(baseline_dir: Path) -> McpFingerprintPlugin:
+    plugin = McpFingerprintPlugin()
+    plugin.load(
+        {
+            "baseline_dir": str(baseline_dir),
+            "bootstrap": True,
+        }
+    )
+    return plugin
+
+
+@pytest.fixture
+def stub_server() -> _StubServer:
+    return _StubServer()
+
+
+def _baseline_path(baseline_dir: Path, server_name: str = "fixture-server") -> Path:
+    return Path(resolve_baseline_path(server_name=server_name, baseline_dir=str(baseline_dir)))
+
+
+def test_explicit_bootstrap_creates_baseline(
+    bootstrap_plugin: McpFingerprintPlugin,
+    baseline_dir: Path,
+    stub_server: _StubServer,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.INFO):
+        bootstrap_plugin.on_server_capabilities_ready("fixture", stub_server)
+
+    baseline_file = _baseline_path(baseline_dir, "fixture")
+    assert baseline_file.is_file()
+    payload = json.loads(baseline_file.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "mcp.fingerprint.baseline.v0.1"
+    assert "baseline created" in caplog.text
+
+
+def test_unchanged(
+    plugin: McpFingerprintPlugin,
+    bootstrap_plugin: McpFingerprintPlugin,
+    baseline_dir: Path,
+    stub_server: _StubServer,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    bootstrap_plugin.on_server_capabilities_ready("fixture", stub_server)
+    caplog.clear()
+
+    with caplog.at_level(logging.INFO):
+        plugin.on_server_capabilities_ready("fixture", stub_server)
+
+    assert "UNCHANGED" in caplog.text
+
+
+def test_changed(
+    plugin: McpFingerprintPlugin,
+    bootstrap_plugin: McpFingerprintPlugin,
+    baseline_dir: Path,
+    stub_server: _StubServer,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    bootstrap_plugin.on_server_capabilities_ready("fixture", stub_server)
+    changed_server = _StubServer(
+        tools=[
+            types.Tool(
+                name="echo",
+                description="Changed description.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"message": {"type": "string"}},
+                    "required": ["message"],
+                },
+            )
+        ]
+    )
+    caplog.clear()
+
+    with caplog.at_level(logging.WARNING):
+        plugin.on_server_capabilities_ready("fixture", changed_server)
+
+    assert "CHANGED" in caplog.text
+
+
+def test_deterministic_changed_output(
+    plugin: McpFingerprintPlugin,
+    bootstrap_plugin: McpFingerprintPlugin,
+    baseline_dir: Path,
+    stub_server: _StubServer,
+) -> None:
+    bootstrap_plugin.on_server_capabilities_ready("fixture", stub_server)
+    changed_server = _StubServer(
+        tools=[
+            types.Tool(
+                name="echo",
+                description="Changed description.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"message": {"type": "string"}},
+                    "required": ["message"],
+                },
+            )
+        ]
+    )
+
+    from mcp_fingerprint import check
+
+    snapshot = plugin._build_snapshot(changed_server)
+    baseline_path = resolve_baseline_path(
+        server_name="fixture", baseline_dir=str(baseline_dir)
+    )
+    first = check(
+        {
+            "schema_version": "mcp.fingerprint.check.request.v0.1",
+            "snapshot": snapshot,
+            "baseline_path": baseline_path,
+        }
+    )
+    second = check(
+        {
+            "schema_version": "mcp.fingerprint.check.request.v0.1",
+            "snapshot": snapshot,
+            "baseline_path": baseline_path,
+        }
+    )
+    assert first["status"] == "CHANGED"
+    assert second["status"] == "CHANGED"
+    assert first["changes"] == second["changes"]
+
+
+def test_multiple_servers_independent_baselines(
+    bootstrap_plugin: McpFingerprintPlugin,
+    baseline_dir: Path,
+) -> None:
+    server_a = _StubServer(name="server-a", version="1.0.0")
+    server_b = _StubServer(name="server-b", version="2.0.0")
+
+    bootstrap_plugin.on_server_capabilities_ready("server-a", server_a)
+    bootstrap_plugin.on_server_capabilities_ready("server-b", server_b)
+
+    baseline_a = _baseline_path(baseline_dir, "server-a")
+    baseline_b = _baseline_path(baseline_dir, "server-b")
+    assert baseline_a.is_file()
+    assert baseline_b.is_file()
+    assert baseline_a != baseline_b
+
+
+def test_icons_meta_execution_do_not_cause_false_drift(
+    plugin: McpFingerprintPlugin,
+    bootstrap_plugin: McpFingerprintPlugin,
+    baseline_dir: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    baseline_tool = types.Tool(
+        name="echo",
+        description="Echo the input message.",
+        inputSchema={
+            "type": "object",
+            "properties": {"message": {"type": "string"}},
+            "required": ["message"],
+        },
+    )
+    live_tool = types.Tool(
+        name="echo",
+        description="Echo the input message.",
+        inputSchema={
+            "type": "object",
+            "properties": {"message": {"type": "string"}},
+            "required": ["message"],
+        },
+        icons=[{"src": "https://example.com/icon.png"}],
+        _meta={"vendor": "fixture"},
+        execution={"mode": "sync"},
+    )
+    bootstrap_plugin.on_server_capabilities_ready(
+        "fixture", _StubServer(tools=[baseline_tool])
+    )
+    caplog.clear()
+
+    with caplog.at_level(logging.INFO):
+        plugin.on_server_capabilities_ready(
+            "fixture", _StubServer(tools=[live_tool])
+        )
+
+    assert "]: UNCHANGED" in caplog.text
+    assert "]: CHANGED" not in caplog.text
+
+
+def test_invalid_baseline_observation_error_gateway_continues(
+    plugin: McpFingerprintPlugin,
+    baseline_dir: Path,
+    stub_server: _StubServer,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    baseline_file = _baseline_path(baseline_dir, "fixture")
+    baseline_file.parent.mkdir(parents=True, exist_ok=True)
+    baseline_file.write_text("{not-valid-json", encoding="utf-8")
+
+    with caplog.at_level(logging.ERROR):
+        plugin.on_server_capabilities_ready("fixture", stub_server)
+
+    assert "observation error" in caplog.text
+    assert "BASELINE_INVALID" in caplog.text
+
+
+def test_missing_baseline_observe_mode_gateway_continues(
+    plugin: McpFingerprintPlugin,
+    baseline_dir: Path,
+    stub_server: _StubServer,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.ERROR):
+        plugin.on_server_capabilities_ready("fixture", stub_server)
+
+    assert "observation error" in caplog.text
+    assert "BASELINE_NOT_FOUND" in caplog.text
+
+
+def test_bootstrap_never_overwrites_existing_baseline(
+    bootstrap_plugin: McpFingerprintPlugin,
+    baseline_dir: Path,
+    stub_server: _StubServer,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    bootstrap_plugin.on_server_capabilities_ready("fixture", stub_server)
+    baseline_file = _baseline_path(baseline_dir, "fixture")
+    original = baseline_file.read_text(encoding="utf-8")
+    caplog.clear()
+
+    with caplog.at_level(logging.INFO):
+        bootstrap_plugin.on_server_capabilities_ready("fixture", stub_server)
+
+    assert baseline_file.read_text(encoding="utf-8") == original
+    assert "bootstrap skipped" in caplog.text
+
+
+def test_changed_never_blocks_gateway(
+    plugin: McpFingerprintPlugin,
+    bootstrap_plugin: McpFingerprintPlugin,
+    baseline_dir: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    bootstrap_plugin.on_server_capabilities_ready(
+        "fixture",
+        _StubServer(
+            tools=[
+                types.Tool(
+                    name="echo",
+                    description="Original.",
+                    inputSchema={"type": "object", "properties": {}},
+                )
+            ],
+        ),
+    )
+    caplog.clear()
+
+    plugin.on_server_capabilities_ready(
+        "fixture",
+        _StubServer(
+            tools=[
+                types.Tool(
+                    name="echo",
+                    description="Changed.",
+                    inputSchema={"type": "object", "properties": {}},
+                )
+            ],
+        ),
+    )
+    assert "CHANGED" in caplog.text
+
+
+def test_plugin_exception_never_blocks_gateway(
+    plugin: McpFingerprintPlugin,
+    stub_server: _StubServer,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with patch.object(
+        plugin, "_build_snapshot", side_effect=RuntimeError("boom")
+    ), caplog.at_level(logging.ERROR):
+        plugin.on_server_capabilities_ready("fixture", stub_server)
+
+    assert "observation error" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_plugin_manager_isolates_lifecycle_exceptions(
+    stub_server: _StubServer,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = PluginManager(
+        enabled_types=["lifecycle"],
+        enabled_plugins={"lifecycle": ["mcp-fingerprint"]},
+        plugin_configs={"mcp-fingerprint": {"baseline_dir": "/tmp/unused"}},
+    )
+    plugin = manager.get_plugins("lifecycle")[0]
+
+    with patch.object(
+        plugin, "on_server_capabilities_ready", side_effect=RuntimeError("boom")
+    ), caplog.at_level(logging.ERROR):
+        await manager.notify_server_capabilities_ready("fixture", stub_server)
+
+    assert "Error in lifecycle plugin" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_tool_registration_unchanged_with_fingerprint_enabled(
+    tmp_path: Path,
+) -> None:
+    mcp_json = tmp_path / "mcp.json"
+    _write_gateway_config(
+        mcp_json,
+        {
+            "fixture": {
+                "command": sys.executable,
+                "args": [FIXTURE_SERVER],
+            }
+        },
+    )
+
+    from mcp_gateway import gateway as gateway_module
+
+    original_cli_args = gateway_module.cli_args
+    gateway_module.cli_args = gateway_module.parse_args(
+        [
+            "--mcp-json-path",
+            str(mcp_json),
+            "-p",
+            "mcp-fingerprint",
+            "--fingerprint-baseline-dir",
+            str(tmp_path / "fp"),
+            "--fingerprint-bootstrap",
+        ]
+    )
+
+    try:
+        async with gateway_module.lifespan(gateway_module.mcp) as context:
+            proxied = context.proxied_servers["fixture"]
+            assert proxied.session is not None
+            assert len(proxied._tools) >= 1
+            tool_names = {tool.name for tool in proxied._tools}
+            assert "echo" in tool_names
+    finally:
+        gateway_module.cli_args = original_cli_args
+
+
+@pytest.mark.asyncio
+async def test_tool_calls_unchanged_with_fingerprint_enabled(
+    tmp_path: Path,
+) -> None:
+    mcp_json = tmp_path / "mcp.json"
+    _write_gateway_config(
+        mcp_json,
+        {
+            "fixture": {
+                "command": sys.executable,
+                "args": [FIXTURE_SERVER],
+            }
+        },
+    )
+
+    from mcp_gateway import gateway as gateway_module
+
+    original_cli_args = gateway_module.cli_args
+    gateway_module.cli_args = gateway_module.parse_args(
+        [
+            "--mcp-json-path",
+            str(mcp_json),
+            "-p",
+            "mcp-fingerprint",
+            "--fingerprint-baseline-dir",
+            str(tmp_path / "fp"),
+            "--fingerprint-bootstrap",
+        ]
+    )
+
+    try:
+        async with gateway_module.lifespan(gateway_module.mcp) as context:
+            proxied = context.proxied_servers["fixture"]
+            result = await proxied.call_tool(
+                plugin_manager=context.plugin_manager,
+                name="echo",
+                arguments={"message": "hello"},
+            )
+            assert result.isError is not True
+            assert any(
+                getattr(content, "text", "") == "hello"
+                for content in (result.content or [])
+            )
+    finally:
+        gateway_module.cli_args = original_cli_args
+
+
+def test_optional_feature_absent_on_unsupported_python_does_not_break_core(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    plugin = McpFingerprintPlugin()
+    with patch(
+        "mcp_gateway.plugins.lifecycle.mcp_fingerprint.fingerprint_supported",
+        return_value=False,
+    ), caplog.at_level(logging.WARNING):
+        plugin.load({})
+
+    assert plugin._enabled is False
+    assert "disabled" in caplog.text
+
+    stub = _StubServer()
+    plugin.on_server_capabilities_ready("fixture", stub)
+
+
+@pytest.mark.skipif(
+    not fingerprint_supported(),
+    reason="integration fixture requires Python 3.12.x",
+)
+@pytest.mark.asyncio
+async def test_real_stdio_fixture_server_starts(tmp_path: Path) -> None:
+    server = Server(
+        "fixture",
+        {"command": sys.executable, "args": [FIXTURE_SERVER]},
+    )
+    await server.start()
+    try:
+        assert server.session is not None
+        assert any(tool.name == "echo" for tool in server._tools)
+    finally:
+        await server.stop()

--- a/tests/test_mcp_fingerprint_plugin.py
+++ b/tests/test_mcp_fingerprint_plugin.py
@@ -72,6 +72,13 @@ class _StubServer:
         ]
 
 
+def _fingerprint_extra_available() -> bool:
+    """True when McpFingerprintPlugin.load() enables the optional extra."""
+    probe = McpFingerprintPlugin()
+    probe.load({})
+    return probe._enabled
+
+
 @pytest.fixture
 def baseline_dir(tmp_path: Path) -> Path:
     return tmp_path / "baselines"
@@ -86,6 +93,8 @@ def plugin(baseline_dir: Path) -> McpFingerprintPlugin:
             "bootstrap": False,
         }
     )
+    if not plugin._enabled:
+        pytest.skip("mcp-fingerprint optional extra not available")
     return plugin
 
 
@@ -98,6 +107,8 @@ def bootstrap_plugin(baseline_dir: Path) -> McpFingerprintPlugin:
             "bootstrap": True,
         }
     )
+    if not plugin._enabled:
+        pytest.skip("mcp-fingerprint optional extra not available")
     return plugin
 
 
@@ -392,6 +403,10 @@ async def test_plugin_manager_isolates_lifecycle_exceptions(
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    not _fingerprint_extra_available(),
+    reason="mcp-fingerprint optional extra not available",
+)
 async def test_tool_registration_unchanged_with_fingerprint_enabled(
     tmp_path: Path,
 ) -> None:
@@ -433,6 +448,10 @@ async def test_tool_registration_unchanged_with_fingerprint_enabled(
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    not _fingerprint_extra_available(),
+    reason="mcp-fingerprint optional extra not available",
+)
 async def test_tool_calls_unchanged_with_fingerprint_enabled(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Add lifecycle hook on_server_capabilities_ready after proxied servers fetch initial tools/list contracts and before gateway registration.

- Enable with -p mcp-fingerprint and optional --fingerprint-baseline-dir / --fingerprint-bootstrap (default observe mode; restart to re-check)
- Optional extra mcp-gateway[fingerprint] gated to Python 3.12.x
- Uses public mcp_fingerprint APIs: project_live_snapshot, save, check
- Observation errors and CHANGED status never block gateway operation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional, observe-only MCP server fingerprinting for creating and comparing capability baselines.
  - Added configuration for baseline location and controlled baseline bootstrapping.
  - Added lifecycle notifications when server capabilities become ready.
  - Fingerprint checks report unchanged, changed, missing, or invalid baselines.

- **Bug Fixes**
  - Fingerprint monitoring remains non-blocking, preserving gateway operation, tool registration, and calls when checks or optional dependencies fail.

- **Documentation**
  - Added setup and usage guidance for installation, activation, configuration, bootstrapping, logging, and restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->