### PR TITLE
Docs: optional TOA verify plugin / CI gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ Here are the tools the MCP is using to create a proxy to the other MCP servers
 
 # Plugins
 
+## Optional TOA verify
+
+Offline [TOA](https://github.com/Carmel-Labs-Inc/toa) gate docs: [docs/toa-optional-plugin.md](docs/toa-optional-plugin.md).
+
 ## Contribute
 For more details on how the plugin system works, how to create your own plugins, or how to contribute, please see the [Plugin System Documentation](./mcp_gateway/plugins/README.md).
 

--- a/docs/toa-optional-plugin.md
+++ b/docs/toa-optional-plugin.md
@@ -17,7 +17,7 @@ This PR ships (1) only.
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 

--- a/docs/toa-optional-plugin.md
+++ b/docs/toa-optional-plugin.md
@@ -1,0 +1,26 @@
+# Optional TOA verify plugin (docs)
+
+Lasso MCP Gateway is plugin-based (guardrails + tracing). Those plugins inspect
+or transform live traffic. [TOA](https://github.com/Carmel-Labs-Inc/toa)
+(`toa/0.1`) is different: offline delivery evidence before enable, not a
+per-call guardrail.
+
+## Suggested contribution shape
+
+1. Docs / example CI step that runs `toa-verify` when `toa.json` is present.
+2. Optional future guardrail that *fails closed* only when an operator opts in
+   and supplies a path to a recent attestation (still not signing every call).
+
+This PR ships (1) only.
+
+```yaml
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass
+```
+
+Example: [`../examples/toa-after-gateway.yml`](../examples/toa-after-gateway.yml).
+
+See also [Plugin System](../mcp_gateway/plugins/README.md).

--- a/docs/toa-optional-plugin.md
+++ b/docs/toa-optional-plugin.md
@@ -17,8 +17,8 @@ This PR ships (1) only.
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 
 Example: [`../examples/toa-after-gateway.yml`](../examples/toa-after-gateway.yml).

--- a/examples/toa-after-gateway.yml
+++ b/examples/toa-after-gateway.yml
@@ -9,5 +9,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d

--- a/examples/toa-after-gateway.yml
+++ b/examples/toa-after-gateway.yml
@@ -9,5 +9,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d

--- a/examples/toa-after-gateway.yml
+++ b/examples/toa-after-gateway.yml
@@ -1,0 +1,13 @@
+# Example only.
+name: Lasso MCP gateway and optional TOA
+on: [workflow_dispatch]
+jobs:
+  toa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass

--- a/mcp_gateway/plugins/README.md
+++ b/mcp_gateway/plugins/README.md
@@ -83,3 +83,7 @@ Plugins are discovered automatically at runtime using Python's package import sy
 ## Plugin Configuration
 
 Plugins can be configured using the `load()` method, which receives a configuration dictionary. This dictionary is currently empty by default, but future versions of MCP Gateway may provide plugin-specific configuration options.
+
+## Optional: Tool Outcome Attestation (TOA)
+
+Offline delivery-evidence verify is documented in [docs/toa-optional-plugin.md](../../docs/toa-optional-plugin.md). It is not a built-in guardrail in this PR.


### PR DESCRIPTION
## Summary

Docs-only. Optional offline `toa-verify` beside the plugin system (not a new built-in guardrail yet).

- `docs/toa-optional-plugin.md`
- `examples/toa-after-gateway.yml`
- Pointers in plugin README and root README

Does not change plugin runtime. No AgentStatus account required to verify.

## Test plan

- [ ] Docs distinguish TOA from live guardrail plugins
- [ ] Example YAML gated on `toa.json`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for optional Tool Outcome Attestation (TOA) verification.
  * Clarified that TOA provides offline delivery-evidence verification, not built-in per-call guardrails or tracing.
  * Added setup instructions, configuration examples, and links to related documentation.
* **Examples**
  * Added an optional, manually triggered verification workflow.
  * Configured verification to require an `agentstatus` attestation, a passing functional layer, and evidence no older than seven days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->