### PR TITLE
fix(sanitizers): fail closed when response plugins error (#16)

### DIFF
--- a/mcp_gateway/plugins/manager.py
+++ b/mcp_gateway/plugins/manager.py
@@ -273,10 +273,13 @@ class PluginManager:
                 else:
                     current_args = plugin.process_request(context_for_plugin)
             except Exception as e:
+                # Fail closed: a guardrail exception must block the request,
+                # not leave the pre-exception args in place for forwarding.
                 logger.error(
                     f"Error in guardrail request plugin {plugin.__class__.__name__}: {e}",
                     exc_info=True,
                 )
+                return None
 
         return current_args
 
@@ -308,10 +311,15 @@ class PluginManager:
                 else:
                     current_response = plugin.process_response(context_for_plugin)
             except Exception as e:
+                # Fail closed (#16): a guardrail that raises (including an
+                # intentional SanitizationError) must not leave the upstream
+                # response bound for forwarding. Re-raise so callers decide
+                # how to surface the block; do not continue the pipeline.
                 logger.error(
                     f"Error in guardrail response plugin {plugin.__class__.__name__}: {e}",
                     exc_info=True,
                 )
+                raise
 
         # Run Tracing plugins for response (for monitoring)
         for plugin in self.get_plugins(TracingPlugin.plugin_type):

--- a/mcp_gateway/sanitizers.py
+++ b/mcp_gateway/sanitizers.py
@@ -15,6 +15,14 @@ class SanitizationError(Exception):
     pass
 
 
+def _blocked_tool_result(message: str) -> types.CallToolResult:
+    """Return a CallToolResult that does not forward upstream content."""
+    return types.CallToolResult(
+        content=[types.TextContent(type="text", text=message)],
+        isError=True,
+    )
+
+
 # Note: These functions now act primarily as dispatchers to the PluginManager.
 # The actual sanitization logic resides within the loaded plugins.
 
@@ -54,18 +62,12 @@ async def sanitize_request(
         sanitized_args = await plugin_manager.process_request(context)
         return sanitized_args
     except Exception as e:
-        # Decide how to handle errors during plugin execution
-        # Option 1: Log and block the request
+        # Fail closed: block the request when request plugins error (#16).
         logger.error(
             f"Error running request plugins for {server_name}/{capability_type}/{name}: {e}",
             exc_info=True,
         )
-        return None  # Block request on plugin error
-        # Option 2: Log and allow original args (potentially risky)
-        # logger.error(f"Error running request plugins for {server_name}/{capability_type}/{name}: {e}", exc_info=True)
-        # return arguments
-        # Option 3: Re-raise a specific error
-        # raise SanitizationError(f"Plugin execution failed: {e}") from e
+        return None
 
 
 async def sanitize_response(
@@ -93,6 +95,9 @@ async def sanitize_response(
 
     Returns:
         The sanitized response, potentially modified by plugins.
+
+    Raises:
+        SanitizationError: When response plugins fail or intentionally block.
     """
     logger.debug(f"Running response plugins for {server_name}/{capability_type}/{name}")
     context = PluginContext(
@@ -113,20 +118,15 @@ async def sanitize_response(
         )
         raise se
     except Exception as e:
-        # Decide how to handle general errors during response plugin execution
-        # Option 1: Log and return original response (potentially revealing sensitive info)
+        # Fail closed (#16): never forward the unsanitized upstream response
+        # when the plugin pipeline errors.
         logger.error(
             f"Error running response plugins for {server_name}/{capability_type}/{name}: {e}",
             exc_info=True,
         )
-        return response  # Return original response on error
-        # Option 2: Raise a generic error
-        # raise SanitizationError(f"Response plugin execution failed: {e}") from e
-        # Option 3: Return a structured error response (if applicable)
-        # return types.CallToolResult(outputs=[{"type": "error", "message": "..."}])
-        # Consider returning an error result instead?
-        # return types.CallToolResult(outputs=[{"type": "error", "message": "Error message"}])
-        return response  # Return original for now
+        raise SanitizationError(
+            f"Response plugin execution failed for {server_name}/{capability_type}/{name}: {e}"
+        ) from e
 
 
 # --- Specific capability wrappers ---
@@ -165,9 +165,11 @@ async def sanitize_resource_read(
         return sanitized_response
     else:
         logger.error(
-            f"Response plugin for resource {uri} returned unexpected type {type(sanitized_response)}. Returning original."
+            f"Response plugin for resource {uri} returned unexpected type {type(sanitized_response)}. Blocking."
         )
-        return content, mime_type
+        raise SanitizationError(
+            f"Response plugin for resource {uri} returned unexpected type {type(sanitized_response)}"
+        )
 
 
 async def sanitize_tool_call_args(
@@ -200,26 +202,35 @@ async def sanitize_tool_call_result(
     """Runs response plugins specifically for tool call results."""
     logger.info(f"Sanitizing tool call result for {server_name} tool {tool_name}")
 
-    sanitized_result = await sanitize_response(
-        plugin_manager=plugin_manager,
-        server_name=server_name,
-        capability_type="tool",
-        name=tool_name,
-        response=result,
-        request_arguments=request_arguments,
-        mcp_context=mcp_context,
-    )
+    try:
+        sanitized_result = await sanitize_response(
+            plugin_manager=plugin_manager,
+            server_name=server_name,
+            capability_type="tool",
+            name=tool_name,
+            response=result,
+            request_arguments=request_arguments,
+            mcp_context=mcp_context,
+        )
+    except SanitizationError as se:
+        logger.error(
+            f"Sanitization blocked tool result for {server_name}/{tool_name}: {se}"
+        )
+        return _blocked_tool_result(f"Gateway policy violation: {se}")
 
-    # Ensure the response is still a CallToolResult
+    # Ensure the response is still a CallToolResult — never fail open to the
+    # unsanitized upstream payload (#16).
     if isinstance(sanitized_result, types.CallToolResult):
         return sanitized_result
-    else:
-        logger.error(
-            f"Response plugin for tool {tool_name} returned unexpected type {type(sanitized_result)}. Returning original."
-        )
-        # Consider returning an error result instead?
-        # return types.CallToolResult(outputs=[{"type": "error", "message": "Error message"}])
-        return result  # Return original for now
+
+    logger.error(
+        f"Response plugin for tool {tool_name} returned unexpected type "
+        f"{type(sanitized_result)}. Blocking original result."
+    )
+    return _blocked_tool_result(
+        f"Gateway policy violation: response plugin for tool {tool_name} "
+        f"returned unexpected type {type(sanitized_result).__name__}"
+    )
 
 
 # Removed old hardcoded sanitization logic for 'AI chip company roadmap' etc.

--- a/mcp_gateway/sanitizers.py
+++ b/mcp_gateway/sanitizers.py
@@ -119,13 +119,14 @@ async def sanitize_response(
         raise se
     except Exception as e:
         # Fail closed (#16): never forward the unsanitized upstream response
-        # when the plugin pipeline errors.
+        # when the plugin pipeline errors. Keep exception text in logs only —
+        # SanitizationError may be mapped to client-facing tool results.
         logger.error(
             f"Error running response plugins for {server_name}/{capability_type}/{name}: {e}",
             exc_info=True,
         )
         raise SanitizationError(
-            f"Response plugin execution failed for {server_name}/{capability_type}/{name}: {e}"
+            f"Response plugin execution failed for {server_name}/{capability_type}/{name}"
         ) from e
 
 
@@ -156,11 +157,12 @@ async def sanitize_resource_read(
         request_arguments={"uri": uri},  # Pass URI as argument context
         mcp_context=mcp_context,
     )
-    # Ensure the response is still in the expected format
+    # Ensure the response is still in the expected format (bytes, optional MIME).
     if (
         isinstance(sanitized_response, tuple)
         and len(sanitized_response) == 2
         and isinstance(sanitized_response[0], bytes)
+        and (sanitized_response[1] is None or isinstance(sanitized_response[1], str))
     ):
         return sanitized_response
     else:
@@ -168,7 +170,7 @@ async def sanitize_resource_read(
             f"Response plugin for resource {uri} returned unexpected type {type(sanitized_response)}. Blocking."
         )
         raise SanitizationError(
-            f"Response plugin for resource {uri} returned unexpected type {type(sanitized_response)}"
+            f"Response plugin for resource {uri} returned unexpected type"
         )
 
 
@@ -213,10 +215,11 @@ async def sanitize_tool_call_result(
             mcp_context=mcp_context,
         )
     except SanitizationError as se:
+        # Client-facing text stays generic; details stay in logs only.
         logger.error(
             f"Sanitization blocked tool result for {server_name}/{tool_name}: {se}"
         )
-        return _blocked_tool_result(f"Gateway policy violation: {se}")
+        return _blocked_tool_result("Gateway policy violation")
 
     # Ensure the response is still a CallToolResult — never fail open to the
     # unsanitized upstream payload (#16).
@@ -227,10 +230,7 @@ async def sanitize_tool_call_result(
         f"Response plugin for tool {tool_name} returned unexpected type "
         f"{type(sanitized_result)}. Blocking original result."
     )
-    return _blocked_tool_result(
-        f"Gateway policy violation: response plugin for tool {tool_name} "
-        f"returned unexpected type {type(sanitized_result).__name__}"
-    )
+    return _blocked_tool_result("Gateway policy violation")
 
 
 # Removed old hardcoded sanitization logic for 'AI chip company roadmap' etc.

--- a/tests/test_sanitizer_fail_closed.py
+++ b/tests/test_sanitizer_fail_closed.py
@@ -10,7 +10,7 @@ from mcp import types
 
 from mcp_gateway.plugins.base import GuardrailPlugin, PluginContext
 from mcp_gateway.plugins.manager import PluginManager
-from mcp_gateway.sanitizers import sanitize_tool_call_result
+from mcp_gateway.sanitizers import sanitize_resource_read, sanitize_tool_call_result
 
 
 SECRET = "super-secret-token-should-not-leak"
@@ -20,6 +20,20 @@ def _tool_result(text: str) -> types.CallToolResult:
     return types.CallToolResult(
         content=[types.TextContent(type="text", text=text)],
         isError=False,
+    )
+
+
+def _is_error(result: types.CallToolResult) -> bool:
+    """Version-safe error flag (mcp may expose is_error and/or isError)."""
+    val = getattr(result, "is_error", None)
+    if val is None:
+        val = getattr(result, "isError", None)
+    return bool(val)
+
+
+def _joined_text(result: types.CallToolResult) -> str:
+    return " ".join(
+        c.text for c in result.content if isinstance(c, types.TextContent)
     )
 
 
@@ -43,17 +57,22 @@ class _RaiseSanitizationPlugin(_BaseGuardrail):
     def process_response(self, context: PluginContext) -> Any:
         from mcp_gateway.sanitizers import SanitizationError
 
-        raise SanitizationError("blocked by policy")
+        raise SanitizationError(f"blocked by policy; payload={SECRET}")
 
 
 class _RaiseGenericPlugin(_BaseGuardrail):
     def process_response(self, context: PluginContext) -> Any:
-        raise RuntimeError("plugin crashed")
+        raise RuntimeError(f"plugin crashed; payload={SECRET}")
 
 
 class _RedactingPlugin(_BaseGuardrail):
     def process_response(self, context: PluginContext) -> Any:
         return _tool_result("[REDACTED]")
+
+
+class _BadMimePlugin(_BaseGuardrail):
+    def process_response(self, context: PluginContext) -> Any:
+        return (b"ok", {"not": "a-string"})
 
 
 def _manager_with(plugin: GuardrailPlugin) -> PluginManager:
@@ -73,12 +92,10 @@ async def test_wrong_type_plugin_does_not_forward_upstream_secret() -> None:
         result=upstream,
     )
     assert isinstance(result, types.CallToolResult)
-    assert result.is_error is True
-    joined = " ".join(
-        c.text for c in result.content if isinstance(c, types.TextContent)
-    )
+    assert _is_error(result) is True
+    joined = _joined_text(result)
     assert SECRET not in joined
-    assert "policy violation" in joined.lower() or "unexpected type" in joined.lower()
+    assert joined == "Gateway policy violation"
 
 
 @pytest.mark.asyncio
@@ -90,12 +107,11 @@ async def test_sanitization_error_plugin_does_not_forward_upstream_secret() -> N
         tool_name="echo",
         result=upstream,
     )
-    assert result.is_error is True
-    joined = " ".join(
-        c.text for c in result.content if isinstance(c, types.TextContent)
-    )
+    assert _is_error(result) is True
+    joined = _joined_text(result)
     assert SECRET not in joined
-    assert "blocked by policy" in joined
+    assert joined == "Gateway policy violation"
+    assert "blocked by policy" not in joined
 
 
 @pytest.mark.asyncio
@@ -107,11 +123,11 @@ async def test_generic_plugin_exception_does_not_forward_upstream_secret() -> No
         tool_name="echo",
         result=upstream,
     )
-    assert result.is_error is True
-    joined = " ".join(
-        c.text for c in result.content if isinstance(c, types.TextContent)
-    )
+    assert _is_error(result) is True
+    joined = _joined_text(result)
     assert SECRET not in joined
+    assert joined == "Gateway policy violation"
+    assert "plugin crashed" not in joined
 
 
 @pytest.mark.asyncio
@@ -123,12 +139,24 @@ async def test_healthy_plugin_still_returns_sanitized_result() -> None:
         tool_name="echo",
         result=upstream,
     )
-    assert result.is_error is False
-    joined = " ".join(
-        c.text for c in result.content if isinstance(c, types.TextContent)
-    )
+    assert _is_error(result) is False
+    joined = _joined_text(result)
     assert joined == "[REDACTED]"
     assert SECRET not in joined
+
+
+@pytest.mark.asyncio
+async def test_resource_bad_mime_type_is_blocked() -> None:
+    from mcp_gateway.sanitizers import SanitizationError
+
+    with pytest.raises(SanitizationError):
+        await sanitize_resource_read(
+            plugin_manager=_manager_with(_BadMimePlugin()),
+            server_name="demo",
+            uri="file:///secret",
+            content=SECRET.encode(),
+            mime_type="text/plain",
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_sanitizer_fail_closed.py
+++ b/tests/test_sanitizer_fail_closed.py
@@ -1,0 +1,150 @@
+"""Regression tests for response-sanitization fail-closed behavior (#16)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock
+
+import pytest
+from mcp import types
+
+from mcp_gateway.plugins.base import GuardrailPlugin, PluginContext
+from mcp_gateway.plugins.manager import PluginManager
+from mcp_gateway.sanitizers import sanitize_tool_call_result
+
+
+SECRET = "super-secret-token-should-not-leak"
+
+
+def _tool_result(text: str) -> types.CallToolResult:
+    return types.CallToolResult(
+        content=[types.TextContent(type="text", text=text)],
+        isError=False,
+    )
+
+
+class _BaseGuardrail(GuardrailPlugin):
+    def load(self, config: Optional[Dict[str, Any]] = None) -> None:
+        return None
+
+    def process_request(self, context: PluginContext) -> Optional[Dict[str, Any]]:
+        return context.arguments
+
+    def process_response(self, context: PluginContext) -> Any:
+        return context.response
+
+
+class _WrongTypePlugin(_BaseGuardrail):
+    def process_response(self, context: PluginContext) -> Any:
+        return "not-a-call-tool-result"
+
+
+class _RaiseSanitizationPlugin(_BaseGuardrail):
+    def process_response(self, context: PluginContext) -> Any:
+        from mcp_gateway.sanitizers import SanitizationError
+
+        raise SanitizationError("blocked by policy")
+
+
+class _RaiseGenericPlugin(_BaseGuardrail):
+    def process_response(self, context: PluginContext) -> Any:
+        raise RuntimeError("plugin crashed")
+
+
+class _RedactingPlugin(_BaseGuardrail):
+    def process_response(self, context: PluginContext) -> Any:
+        return _tool_result("[REDACTED]")
+
+
+def _manager_with(plugin: GuardrailPlugin) -> PluginManager:
+    manager = PluginManager.__new__(PluginManager)
+    manager.enabled_types = {GuardrailPlugin.plugin_type}
+    manager._plugins = {GuardrailPlugin.plugin_type: [plugin]}
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_wrong_type_plugin_does_not_forward_upstream_secret() -> None:
+    upstream = _tool_result(SECRET)
+    result = await sanitize_tool_call_result(
+        plugin_manager=_manager_with(_WrongTypePlugin()),
+        server_name="demo",
+        tool_name="echo",
+        result=upstream,
+    )
+    assert isinstance(result, types.CallToolResult)
+    assert result.is_error is True
+    joined = " ".join(
+        c.text for c in result.content if isinstance(c, types.TextContent)
+    )
+    assert SECRET not in joined
+    assert "policy violation" in joined.lower() or "unexpected type" in joined.lower()
+
+
+@pytest.mark.asyncio
+async def test_sanitization_error_plugin_does_not_forward_upstream_secret() -> None:
+    upstream = _tool_result(SECRET)
+    result = await sanitize_tool_call_result(
+        plugin_manager=_manager_with(_RaiseSanitizationPlugin()),
+        server_name="demo",
+        tool_name="echo",
+        result=upstream,
+    )
+    assert result.is_error is True
+    joined = " ".join(
+        c.text for c in result.content if isinstance(c, types.TextContent)
+    )
+    assert SECRET not in joined
+    assert "blocked by policy" in joined
+
+
+@pytest.mark.asyncio
+async def test_generic_plugin_exception_does_not_forward_upstream_secret() -> None:
+    upstream = _tool_result(SECRET)
+    result = await sanitize_tool_call_result(
+        plugin_manager=_manager_with(_RaiseGenericPlugin()),
+        server_name="demo",
+        tool_name="echo",
+        result=upstream,
+    )
+    assert result.is_error is True
+    joined = " ".join(
+        c.text for c in result.content if isinstance(c, types.TextContent)
+    )
+    assert SECRET not in joined
+
+
+@pytest.mark.asyncio
+async def test_healthy_plugin_still_returns_sanitized_result() -> None:
+    upstream = _tool_result(SECRET)
+    result = await sanitize_tool_call_result(
+        plugin_manager=_manager_with(_RedactingPlugin()),
+        server_name="demo",
+        tool_name="echo",
+        result=upstream,
+    )
+    assert result.is_error is False
+    joined = " ".join(
+        c.text for c in result.content if isinstance(c, types.TextContent)
+    )
+    assert joined == "[REDACTED]"
+    assert SECRET not in joined
+
+
+@pytest.mark.asyncio
+async def test_guardrail_request_exception_blocks_args() -> None:
+    class BoomRequest(_BaseGuardrail):
+        def process_request(self, context: PluginContext) -> Optional[Dict[str, Any]]:
+            raise RuntimeError("request plugin crashed")
+
+    manager = _manager_with(BoomRequest())
+    blocked = await manager.process_request(
+        PluginContext(
+            server_name="demo",
+            capability_type="tool",
+            capability_name="echo",
+            arguments={"path": "/etc/shadow"},
+            mcp_context=MagicMock(),
+        )
+    )
+    assert blocked is None


### PR DESCRIPTION
## Summary

Response guardrails that raised or returned a non-`CallToolResult` left the upstream tool payload bound for forwarding, so sanitization failed open (#16).

This change:
- re-raises guardrail response exceptions in `PluginManager` (so intentional `SanitizationError` is reachable)
- blocks requests when a request guardrail raises
- returns an `isError` tool result (never the original secret-bearing payload) when sanitization cannot complete

Fixes #16

## Test plan

- [x] `python3 -m pytest tests/test_sanitizer_fail_closed.py -q` (5 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests and responses are now blocked when safety checks encounter errors.
  * Prevents unsanitized content, secrets, or invalid tool arguments from continuing through the pipeline.
  * Tool failures now return a consistent “Gateway policy violation” message instead of exposing internal error details.
  * Invalid resource responses are rejected rather than passed through.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->